### PR TITLE
[PG-23724][PG-23835]Fix webpack@5 compatibility, publish @campuskudos/antd v3.7.4

### DIFF
--- a/components/version/index.tsx
+++ b/components/version/index.tsx
@@ -1,3 +1,3 @@
-import { version } from '../../package.json';
+import packageInfo from '../../package.json';
 
-export default version;
+export default packageInfo.version;

--- a/package.json
+++ b/package.json
@@ -222,6 +222,9 @@
   "pre-commit": [
     "lint-staged"
   ],
+  "resolutions": {
+    "graceful-fs": "^4.2.9"
+  },
   "sideEffects": [
     "es/**/style/*",
     "lib/**/style/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "antd",
-  "version": "3.7.3",
+  "name": "@campuskudos/antd",
+  "version": "3.7.4",
   "title": "Ant Design",
   "description": "An enterprise-class UI design language and React-based implementation",
   "homepage": "http://ant.design/",
@@ -20,10 +20,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/ant-design/ant-design"
-  },
-  "bugs": {
-    "url": "https://github.com/ant-design/ant-design/issues"
+    "url": "https://github.com/campuskudos/ant-design"
   },
   "main": "lib/index.js",
   "module": "es/index.js",


### PR DESCRIPTION
### Description
- Check base changes from antd@3.7.3
- Fix package.json import for webpack@5 compatibility (49eea63)
- Publish @campuskudos/antd v3.7.4 (6f4ac82)


### ☑️  Verification Process
Tested on local with package `@campuskudos/antd@3.7.3-0`


### 🔗 Applicable Issues
[PG-23724](https://peoplegrove.atlassian.net/browse/PG-23724) Update React Dependencies - CRA 5, Webpack 5
[PG-23835](https://peoplegrove.atlassian.net/browse/PG-23835) Build @campuskudos/antd v3.7.4 package and publish


### 💡 Background and solution
- To upgrade to CRA 5 and webpack 5, we needed to fix the compatibility issues in ant-design.
- Antd has fixed the issues in newer versions but as we have kept our packages locked to v3.7.3, we cannot directly update to the latest version.
- We have forked the antd repo and checked out v3.7.3, cherry-pick compatibility changes on top of it and publish our new npm package with the fixes.


### 📝 Changelog
- 49eea63428f8910c317d9dedf8f506e6101b5ec3
- ddeb97801b6c290f777d67cca3b9726906efa847
- 6f4ac82001f89c7c5fa1074a21b64dd2c062dd7c
